### PR TITLE
chore(deps): Dependabot で ESLint のメジャー更新を除外

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
+    ignore:
+      # eslint-config-next が同梱する parser / eslint-plugin-react が ESLint 10 に未対応のため保留
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## 概要

Dependabot が提案する ESLint のメジャーバージョン更新（v10 系）を一時的に除外する。

## 背景

ESLint 10 に上げると `yarn lint` が実行不能になる（#402 で検証済み）。

原因は以下の 2 点で、いずれも本リポジトリ側では対処できない。

1. **`eslint-config-next` 同梱パーサーの非互換**
   `eslint-config-next/parser` が返す ScopeManager に `addGlobals` が実装されておらず、ESLint 10 の `SourceCode#finalize` で `TypeError: scopeManager.addGlobals is not a function` が発生する。
   `next` / `eslint-config-next` を 16.3.0 および 16.3.1-canary.13 まで上げても未解消。

2. **`eslint-plugin-react` が ESLint 10 未対応**
   最新の 7.37.5 でも peerDependencies は `eslint: ... || ^9.7` 止まりで、ESLint 10 で削除された `context.getFilename()` を参照しているため `TypeError: contextOrFilename.getFilename is not a function` が発生する。

なお `typescript-eslint` は 8.67.0 で ESLint 10 対応済み（peer に `^10.0.0` 追加）だが、上記 2 点が残るため単体では解決しない。

## 変更内容

`.github/dependabot.yml` の npm ecosystem に `ignore` を追加し、`eslint` の `version-update:semver-major` を対象外にする。

## 今後

`eslint-config-next` 側が ESLint 10 に対応したら、この `ignore` 設定を削除して改めて追従する。
