### PR TITLE
ci: ワークフローの権限明示・immutable インストール・キャッシュ導入

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,11 @@ on:
   schedule:
     - cron: '19 5 * * 6'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze
@@ -46,22 +51,6 @@ jobs:
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-      #    and modify them (or add more) to build your code if your project
-      #    uses a compiled language
-
-      #- run: |
-      #   make bootstrap
-      #   make release
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     types:
       - completed
+permissions:
+  contents: write
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -12,13 +14,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
       - name: yarn enable
         run: corepack enable
+      # Corepack で Yarn 4 を有効化した後でないと Yarn 1 のキャッシュ位置が使われる
+      - name: Configure Yarn cache
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'yarn'
       - name: Install dependencies
-        run: yarn --frozen-lockfile
+        run: yarn install --immutable
       - name: Page Generate
         run: yarn build
       - name: Deploy

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -2,6 +2,9 @@ name: eslint
 on:
   pull_request:
     types: [opened, synchronize]
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   eslint:
     name: eslint
@@ -9,13 +12,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
       - name: yarn enable
         run: corepack enable
+      # Corepack で Yarn 4 を有効化した後でないと Yarn 1 のキャッシュ位置が使われる
+      - name: Configure Yarn cache
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'yarn'
       - name: yarn install
-        run: yarn install
+        run: yarn install --immutable
       - name: eslint review
         uses: reviewdog/action-eslint@v1
         with:

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -5,19 +5,27 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
       - name: yarn enable
         run: corepack enable
+      # Corepack で Yarn 4 を有効化した後でないと Yarn 1 のキャッシュ位置が使われる
+      - name: Configure Yarn cache
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'yarn'
       - name: yarn install
-        run: yarn install
+        run: yarn install --immutable
       - name: Run jest test
         run: yarn test --coverage
       - name: Upload Coverage


### PR DESCRIPTION
## 概要

GitHub Actions ワークフローの権限設定・依存インストール方式・キャッシュを見直しました。

## 変更内容

### 1. `--frozen-lockfile` の廃止（実害あり）

`deploy.yml` で使用していた `yarn --frozen-lockfile` は Yarn 1 時代のフラグで、Yarn 4 では非推奨警告が出ます。

```
➤ YN0050: The --frozen-lockfile option is deprecated;
   use --immutable and/or --immutable-cache instead
```

またこの警告は出るものの、`eslint.yml` / `jest.yml` に至ってはフラグ自体が無く、CI 上で lockfile が書き換わっても検知できない状態でした。3 ファイルすべて `yarn install --immutable` へ統一しています。

### 2. `permissions` の明示（最小権限化）

いずれのワークフローも `GITHUB_TOKEN` のデフォルト権限に依存していたため、必要な権限のみを明示しました。

| ワークフロー | 付与した権限 |
| --- | --- |
| `deploy.yml` | `contents: write` |
| `eslint.yml` | `contents: read` / `pull-requests: write`（reviewdog のレビュー投稿用） |
| `jest.yml` | `contents: read` |
| `codeql-analysis.yml` | `actions: read` / `contents: read` / `security-events: write` |

### 3. 依存キャッシュの追加

毎回ゼロから `yarn install` していたため、`cache: 'yarn'` を追加しました。

ただし `actions/setup-node` のキャッシュ処理は Yarn のバージョンを検出してキャッシュ位置を決めるため、**Corepack 有効化前に指定すると Yarn 1 のパスが使われて機能しません**。そのため `corepack enable` の後段でキャッシュ設定を適用する構成としています。

```yaml
- name: yarn enable
  run: corepack enable
# Corepack で Yarn 4 を有効化した後でないと Yarn 1 のキャッシュ位置が使われる
- name: Configure Yarn cache
  uses: actions/setup-node@v7
  with:
    node-version: '24'
    cache: 'yarn'
```

### 4. `actions/setup-node` を v6 → v7 へ

v7.0.0 が最新です。入力パラメータに破壊的変更はありません。

なお `actions/checkout@v6`・`codecov/codecov-action@v7`・`github/codeql-action@v4` は確認済みで、いずれも最新のため据え置きです。

### 5. CodeQL の `autobuild` 削除

解析対象は `javascript` のみで、インタープリタ言語に対して `autobuild` は何も行いません。あわせて、コンパイル言語向けのコメントアウト済みサンプルも削除しました。

## 確認事項

- [x] `yarn install --immutable` … 非推奨警告が出ないことを確認
- [x] `yarn test` … 3 suites / 5 tests パス
- [x] `yarn lint` … ESLint・Prettier ともにパス
- [x] `yarn build` … 静的エクスポート成功
- [x] 全ワークフローに `permissions` が設定されていることを確認
