### PR TITLE
docs: プロジェクトドキュメントを実際の構成に同期

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,6 @@
       "extensions": [
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "bradlc.vscode-tailwindcss",
-        "stylelint.vscode-stylelint",
         "GitHub.copilot",
         "GitHub.copilot-chat"
       ],

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,19 +24,30 @@ Next.js (App Router) を使用した静的サイトで、GitHub Pagesにデプ�
 
 ```
 portfolio/
-├── app/                    # Next.js App Router
-│   ├── layout.tsx          # ルートレイアウト
-│   ├── page.tsx            # トップページ
-│   └── _layout/            # レイアウトコンポーネント
-│       └── footer.tsx      # フッター
-├── styles/                 # スタイルファイル
-│   ├── globals.css         # グローバルスタイル
-│   ├── *.module.css        # CSSモジュール
-├── test/                   # テストファイル
-│   └── pages/              # ページテスト
-├── public/                 # 静的ファイル
-└── config/                 # 設定ファイル
-    └── jest/               # Jest関連設定
+├── app/                        # Next.js App Router
+│   ├── layout.tsx              # ルートレイアウト
+│   ├── page.tsx                # トップページ
+│   ├── robots.ts               # robots.txt を生成
+│   ├── sitemap.ts              # sitemap.xml を生成
+│   ├── icon.svg                # ファビコン（favicon.ico / apple-icon.png も同階層）
+│   └── _components/            # UIコンポーネント（ルーティング対象外）
+│       ├── atoms/              # 最小単位のコンポーネント
+│       │   └── section.tsx
+│       └── organisms/          # ページを構成するブロック
+│           ├── contributions.tsx
+│           ├── footer.tsx
+│           ├── hero.tsx
+│           ├── links.tsx
+│           └── skills.tsx
+├── styles/                     # スタイルファイル
+│   ├── globals.css             # グローバルスタイル
+│   └── *.module.css            # CSSモジュール
+├── test/                       # テストファイル
+│   ├── tsconfig.jest.json      # テスト用TypeScript設定
+│   └── pages/                  # テスト本体とスナップショット
+├── public/                     # 静的ファイル（CNAME, .nojekyll）
+└── config/                     # 設定ファイル
+    └── jest/                   # Jest関連設定
 ```
 
 ## コーディング規約
@@ -125,9 +136,11 @@ it('renders correctly', () => {
 
 2. **App Router**: `pages/` ディレクトリではなく `app/` ディレクトリを使用
 
-3. **レイアウトコンポーネント**: 共通レイアウトは `app/_layout/` に配置（アンダースコアプレフィックスでルーティング対象外）
+3. **コンポーネント配置**: UIコンポーネントは `app/_components/` に配置（アンダースコアプレフィックスでルーティング対象外）。Atomic Design に沿って、最小単位は `atoms/`、ページを構成するブロックは `organisms/` へ置く
 
 4. **メタデータ**: `layout.tsx` で `Metadata` 型を使用してSEO設定
+
+5. **robots.txt / sitemap.xml**: `app/robots.ts` と `app/sitemap.ts` で生成する。静的エクスポートのため `export const dynamic = 'force-static'` が必須
 
 ## 新規ファイル作成時のテンプレート
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 First, run the development server:
 
 ```bash
-npm run dev
-# or
 yarn dev
 ```
 


### PR DESCRIPTION
## 概要

`.github/copilot-instructions.md` の記述が実装と乖離していたため、実態に合わせて更新しました。あわせて README と devcontainer の不整合も解消しています。

## 背景

`copilot-instructions.md` は GitHub Copilot が参照する前提知識です。ここが実態とずれていると **存在しないパスを前提にコードが生成される**ため、優先的に修正しました。

## 変更内容

### 1. ディレクトリ構造の修正

過去のリファクタリングで `app/_layout/` は廃止され、`app/_components/` 配下の Atomic Design 構成へ移行済みでしたが、ドキュメントには反映されていませんでした。

```diff
-│   └── _layout/            # レイアウトコンポーネント
-│       └── footer.tsx      # フッター
+│   └── _components/            # UIコンポーネント（ルーティング対象外）
+│       ├── atoms/              # 最小単位のコンポーネント
+│       │   └── section.tsx
+│       └── organisms/          # ページを構成するブロック
+│           ├── contributions.tsx
+│           ├── footer.tsx
...
```

あわせて、記載が漏れていた以下も追記しました。

- `app/robots.ts` / `app/sitemap.ts`
- `app/icon.svg`（`favicon.ico` / `apple-icon.png`）
- `test/tsconfig.jest.json`
- `public/` の内訳（`CNAME`, `.nojekyll`）

### 2. 注意事項の更新

「レイアウトコンポーネントは `app/_layout/` に配置」という記述を、実際の運用にあわせて書き換えました。

```diff
-3. **レイアウトコンポーネント**: 共通レイアウトは `app/_layout/` に配置
+3. **コンポーネント配置**: UIコンポーネントは `app/_components/` に配置。
+   Atomic Design に沿って、最小単位は `atoms/`、ページを構成するブロックは `organisms/` へ置く
```

また、静的エクスポート環境で `robots.ts` / `sitemap.ts` を扱う際にハマりやすい `export const dynamic = 'force-static'` の必要性を明記しました。

### 3. README を Yarn へ統一

`packageManager: "yarn@4.18.0"` で固定されているにもかかわらず `npm run dev` が先頭で案内されていたため、Yarn のみの記載に変更しました。

### 4. 未使用の VS Code 拡張を削除

`.devcontainer/devcontainer.json` に Tailwind CSS と Stylelint の拡張が指定されていましたが、いずれもプロジェクトに導入されていないため削除しました。

```diff
-        "bradlc.vscode-tailwindcss",
-        "stylelint.vscode-stylelint",
```

## 補足

コンポーネントの記述スタイル（`import React, { FC }` の扱い）については、実コードの変更を伴うため本 PR には含めず、別途対応します。

## 確認事項

- [x] ドキュメント記載のパスがすべて実在することを確認
- [x] `yarn test` … 3 suites / 5 tests パス
- [x] `yarn lint` … ESLint・Prettier ともにパス
- [x] `yarn build` … 静的エクスポート成功
